### PR TITLE
Implement support for multiple Bayernluefter devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,29 @@ The Bayernlüfter needs to have a WiFi-Module and additional humidity sensors in
 
 The component enables controlling the fan, monitoring humditity and toggling Power and Timer mode.
 
-Example configuration.yaml
+You can configure this device as a top-level entity, and it will add all sensors and switches for above mentioned features.
 
 ```yaml
+# Example configuration.yaml
 bayernluefter:
     resource: http://192.168.178.5
     scan_interval: 30 # Optional scan interval in seconds
 ```
+
+If you want to use several devices you can pass a list of resources.
+Each resource needs a unique name.
+
+```yaml
+# Example configuration.yaml
+bayernluefter:
+  - name: Living Room
+    resource: http://192.168.178.5
+    scan_interval: 30 # Optional scan interval in seconds
+  - name: Kitchen
+    resource: http://192.168.179.6
+    scan_interval: 30 # Optional scan interval in seconds
+```
+
 
 ## Installation
 

--- a/custom_components/bayernluefter/__init__.py
+++ b/custom_components/bayernluefter/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.event import async_track_time_interval
 from datetime import timedelta
-from datetime import datetime
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import aiohttp_client
 
@@ -39,62 +38,77 @@ ICON = {
     "energy": "mdi:power-plug",
 }
 
+BL_SCHEMA = {
+    DOMAIN: vol.Schema(
+        {
+            vol.Required(CONF_RESOURCE): cv.url,
+            vol.Optional(
+                CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+            ): cv.positive_int,
+            vol.Optional(
+                CONF_NAME, default=DEFAULT_NAME,
+            ): cv.string,
+        }
+    ),
+}
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_RESOURCE): cv.url,
-                vol.Optional(
-                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-                ): cv.positive_int,
-                vol.Optional(
-                    CONF_NAME, default=DEFAULT_NAME,
-                ): cv.string,
-            }
-        ),
-    },
+    vol.Any([BL_SCHEMA], BL_SCHEMA),
     extra=vol.ALLOW_EXTRA,
 )
 
 
-async def async_setup(hass: HomeAssistant, config):
+async def async_setup(hass: HomeAssistant, raw_config):
     """Set up the BLNET component"""
 
-    config = config[DOMAIN]
-    resource = config.get(CONF_RESOURCE)
-    scan_interval = config.get(CONF_SCAN_INTERVAL)
-    name = config.get(CONF_NAME)
-    session = aiohttp_client.async_get_clientsession(hass)
+    configs = raw_config[DOMAIN]
+    if not isinstance(configs, list):
+        configs = [configs]
+    hass.data[DOMAIN] = {}
+    used_names = set()
 
-    # Initialize the BL-NET sensor
-    try:
-        blnet = Bayernluefter(resource, session)
-    except (ValueError, AssertionError) as ex:
-        if isinstance(ex, ValueError):
-            _LOGGER.error("No Bayernluefter reached at {}".format(resource))
-        else:
-            _LOGGER.error("Configuration invalid: {}".format(ex))
-        return False
+    for config in configs:
+        resource = config.get(CONF_RESOURCE)
+        scan_interval = config.get(CONF_SCAN_INTERVAL)
+        name = config.get(CONF_NAME)
+        session = aiohttp_client.async_get_clientsession(hass)
 
-    # set the communication entity
-    hass.data["DATA_{}_{}".format(DOMAIN, name)] = blnet
+        # Validate that unique BL entities are created
+        if name in used_names:
+            _LOGGER.error("Configuration invalid: use unique names when setting up multiple BayernLuefter entities")
+            del hass.data[DOMAIN]
+            return False
+        used_names.add(name)
 
-    # make sure the communication device gets updated once in a while
-    async def fetch_data(*_):
-        return await blnet.update()
+        # Initialize the BL-NET sensor
+        try:
+            blnet = Bayernluefter(resource, session)
+        except (ValueError, AssertionError) as ex:
+            if isinstance(ex, ValueError):
+                _LOGGER.error("No Bayernluefter reached at {}".format(resource))
+            else:
+                _LOGGER.error("Configuration invalid: {}".format(ex))
+            del hass.data[DOMAIN]
+            return False
 
-    # Get the latest data from REST API and load
-    # sensors and switches accordingly
-    disc_info = {
-        "domain": DOMAIN,
-        "name": name,
-    }
-    hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, disc_info, config))
-    hass.async_create_task(async_load_platform(hass, "switch", DOMAIN, disc_info, config))
-    hass.async_create_task(async_load_platform(hass, "fan", DOMAIN, disc_info, config))
+        # set the communication entity
+        hass.data[DOMAIN][name] = blnet
 
-    # Repeat if data fetching fails at first
-    async_track_time_interval(hass, fetch_data, timedelta(seconds=scan_interval))
+        # make sure the communication device gets updated once in a while
+        async def fetch_data(*_):
+            return await blnet.update()
+
+        # Get the latest data from REST API and load
+        # sensors and switches accordingly
+        disc_info = {
+            "domain": DOMAIN,
+            "name": name,
+        }
+        hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, disc_info, config))
+        hass.async_create_task(async_load_platform(hass, "switch", DOMAIN, disc_info, config))
+        hass.async_create_task(async_load_platform(hass, "fan", DOMAIN, disc_info, config))
+
+        # Repeat if data fetching fails at first
+        async_track_time_interval(hass, fetch_data, timedelta(seconds=scan_interval))
 
     # Fetch method takes care of adding dicovered sensors
     return True

--- a/custom_components/bayernluefter/__init__.py
+++ b/custom_components/bayernluefter/__init__.py
@@ -9,7 +9,6 @@ from homeassistant.helpers.discovery import async_load_platform
 
 from homeassistant.const import (
     CONF_RESOURCE,
-    CONF_PASSWORD,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
     TEMP_CELSIUS,
@@ -38,7 +37,7 @@ ICON = {
     "energy": "mdi:power-plug",
 }
 
-BL_SCHEMA = {
+BL_SCHEMA = vol.Schema({
     DOMAIN: vol.Schema(
         {
             vol.Required(CONF_RESOURCE): cv.url,
@@ -49,12 +48,10 @@ BL_SCHEMA = {
                 CONF_NAME, default=DEFAULT_NAME,
             ): cv.string,
         }
-    ),
-}
-CONFIG_SCHEMA = vol.Schema(
-    vol.Any([BL_SCHEMA], BL_SCHEMA),
+    )},
     extra=vol.ALLOW_EXTRA,
 )
+CONFIG_SCHEMA = vol.Any([BL_SCHEMA], BL_SCHEMA),
 
 
 async def async_setup(hass: HomeAssistant, raw_config):

--- a/custom_components/bayernluefter/__init__.py
+++ b/custom_components/bayernluefter/__init__.py
@@ -37,21 +37,23 @@ ICON = {
     "energy": "mdi:power-plug",
 }
 
-BL_SCHEMA = vol.Schema({
-    DOMAIN: vol.Schema(
-        {
-            vol.Required(CONF_RESOURCE): cv.url,
-            vol.Optional(
-                CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-            ): cv.positive_int,
-            vol.Optional(
-                CONF_NAME, default=DEFAULT_NAME,
-            ): cv.string,
-        }
-    )},
+BL_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_RESOURCE): cv.url,
+        vol.Optional(
+            CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+        ): cv.positive_int,
+        vol.Optional(
+            CONF_NAME, default=DEFAULT_NAME,
+        ): cv.string,
+    }
+)
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.All(cv.ensure_list, [BL_SCHEMA]),
+    },
     extra=vol.ALLOW_EXTRA,
 )
-CONFIG_SCHEMA = vol.Any([BL_SCHEMA], BL_SCHEMA)
 
 
 async def async_setup(hass: HomeAssistant, raw_config):

--- a/custom_components/bayernluefter/__init__.py
+++ b/custom_components/bayernluefter/__init__.py
@@ -51,7 +51,7 @@ BL_SCHEMA = vol.Schema({
     )},
     extra=vol.ALLOW_EXTRA,
 )
-CONFIG_SCHEMA = vol.Any([BL_SCHEMA], BL_SCHEMA),
+CONFIG_SCHEMA = vol.Any([BL_SCHEMA], BL_SCHEMA)
 
 
 async def async_setup(hass: HomeAssistant, raw_config):

--- a/custom_components/bayernluefter/fan.py
+++ b/custom_components/bayernluefter/fan.py
@@ -30,7 +30,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         return False
     domain = discovery_info["domain"]
     name = discovery_info["name"]
-    bayernluefter = hass.data["DATA_{}_{}".format(domain, name)]
+    bayernluefter = hass.data[domain][name]
     ent = [
         BayernluefterFan(name=f"{name} Fan Speed", bayernluefter=bayernluefter),
     ]

--- a/custom_components/bayernluefter/sensor.py
+++ b/custom_components/bayernluefter/sensor.py
@@ -45,7 +45,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         return False
     domain = discovery_info["domain"]
     name = discovery_info["name"]
-    bayernluefter = hass.data["DATA_{}_{}".format(domain, name)]
+    bayernluefter = hass.data[domain][name]
     ent = [BayernluefterSensor(name=name, bayernluefter=bayernluefter)]
     ent.extend(
         [

--- a/custom_components/bayernluefter/switch.py
+++ b/custom_components/bayernluefter/switch.py
@@ -30,7 +30,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         return False
     domain = discovery_info["domain"]
     name = discovery_info["name"]
-    bayernluefter = hass.data["DATA_{}_{}".format(domain, name)]
+    bayernluefter = hass.data[domain][name]
     ent = [
         BayernluefterPowerSwitch(name=f"{name} Power", bayernluefter=bayernluefter),
         BayernluefterTimerSwitch(name=f"{name} Timer", bayernluefter=bayernluefter),


### PR DESCRIPTION
This implements the feature requested in #5 
The configuration now supports passing a list of resources with unique names which will create entries for each Bayernluefter.