### PR TITLE
fix unit-of-measure for humidity transport

### DIFF
--- a/custom_components/bayernluefter/sensor.py
+++ b/custom_components/bayernluefter/sensor.py
@@ -21,7 +21,7 @@ from pyernluefter import Bayernluefter
 
 _LOGGER = logging.getLogger(__name__)
 
-MILLIGRAMS_PER_DAY = "mg/d"
+GRAMS_PER_DAY = "g/d"
 
 TEMP_MEASURES = ["Temp_In", "Temp_Out", "Temp_Fresh"]
 REL_HUM_MEASURES = [
@@ -86,7 +86,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
             BayernluefterSpecialSensor(
                 name=f"{name} {mt}",
                 measure_type=mt,
-                unit_of_measurement=MILLIGRAMS_PER_DAY,
+                unit_of_measurement=GRAMS_PER_DAY,
                 bayernluefter=bayernluefter,
             )
             for mt in HUM_TRANSPORT_MEASURES


### PR DESCRIPTION
original unit (as shown in the device website) is `g/d`, not `mg/d`

Correct unit of measure after change:
![image](https://github.com/nielstron/ha_bayernluefter/assets/375950/f0ad6be4-d742-4a30-bd94-f5672a659269)
